### PR TITLE
Somewhat large cleanup

### DIFF
--- a/PasteSolutions/Database/Models/DbSnippet.cs
+++ b/PasteSolutions/Database/Models/DbSnippet.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace PasteSolutions.Database.Models
 {

--- a/PasteSolutions/Objects/DatabaseConfiguration.cs
+++ b/PasteSolutions/Objects/DatabaseConfiguration.cs
@@ -1,0 +1,11 @@
+﻿namespace PasteSolutions.Objects
+{
+    public class DatabaseConfiguration
+    {
+        public string Host { get; set; }
+        public int Port { get; set; }
+        public string Database { get; set; }
+        public string Username { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/PasteSolutions/PasteSolutions.csproj
+++ b/PasteSolutions/PasteSolutions.csproj
@@ -3,26 +3,26 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UserSecretsId>eaaf2d7b-affd-4932-8261-db164096d88a</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BuildBundlerMinifier" Version="2.9.406"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0-preview7*"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0-preview7*"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.0.0-preview7*">
+    <PackageReference Include="BuildBundlerMinifier" Version="3.1.430" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0-preview7*"/>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0-preview7*"/>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.7.12"/>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0-preview*"/>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.0-preview7*"/>
-    <PackageReference Include="AspNetCoreRateLimit" Version="3.0.5"/>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.0.0-preview7.19365.7"/>
-    <ProjectReference Include="../libs/UniqueId/src/UniqueID/UniqueID.csproj"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.1" />
+    <PackageReference Include="AspNetCoreRateLimit" Version="3.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.0.0" />
+    <ProjectReference Include="../libs/UniqueId/src/UniqueID/UniqueID.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="static-pages/**" CopyToPublishDirectory="Always"/>
+    <Content Include="static-pages/**" CopyToPublishDirectory="Always" />
   </ItemGroup>
 </Project>

--- a/PasteSolutions/Program.cs
+++ b/PasteSolutions/Program.cs
@@ -1,14 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
-using AspNetCoreRateLimit;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace PasteSolutions
 {
@@ -21,6 +14,7 @@ namespace PasteSolutions
             Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration(x => {
                     x.AddJsonFile("Config/config.json");
+                    x.AddEnvironmentVariables("PASTE_SOLUTIONS_");
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {

--- a/PasteSolutions/Properties/launchSettings.json
+++ b/PasteSolutions/Properties/launchSettings.json
@@ -19,12 +19,12 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
-        "DB_USERNAME": "izumemori",
-        "DB_DATABASE": "paste_solutions_dev",
-        "DB_PORT": "46420",
-        "DB_PASSWORD": "MJ3g4POVz[jYpT_wfFeK",
-        "DB_HOST": "db.paste.solutions",
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "PASTE_SOLUTIONS_DB__PASSWORD": "hunter2",
+        "PASTE_SOLUTIONS_DB__DATABASE": "izu",
+        "PASTE_SOLUTIONS_DB__HOST": "10.0.4.3",
+        "PASTE_SOLUTIONS_DB__USERNAME": "izu",
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "PASTE_SOLUTIONS_DB__PORT": "5432"
       },
       "applicationUrl": "http://localhost:5000"
     },

--- a/PasteSolutions/db_v1_v2.sql
+++ b/PasteSolutions/db_v1_v2.sql
@@ -1,0 +1,3 @@
+ALTER TABLE snippets ALTER COLUMN content TYPE TEXT;
+-- so funny thing about timestamptz
+-- it doesn't actually do what you think it does...


### PR DESCRIPTION
This PR aims to clean up the codebase significantly. Here's changes made:

- Database schema
  - The table's `contents` column is no longer `VARCHAR(large number)`, instead it's `TEXT`.
- Code
  - Removed unnecessary usings
  - Now using envvars to pull DB config in
    - Envvar names have changed to allow for sectioning and prefixing: `DB_*` -> `PASTE_SOLUTIONS_DB__*` (yes, that's two underscores)
      - `DB_HOST` -> `PASTE_SOLUTIONS_DB__HOST`
      - `DB_PORT` -> `PASTE_SOLUTIONS_DB__PORT`
      - `DB_DATABASE` -> `PASTE_SOLUTIONS_DB__DATABASE`
      - `DB_USERNAME` -> `PASTE_SOLUTIONS_DB__USERNAME`
      - `DB_PASSWORD` -> `PASTE_SOLUTIONS_DB__PASSWORD`
    - The DB config options are now accessible in KV configuration under `DB` section (i.e. `DB:HOST`, `DB:PORT`, etc)
    - Added strongly-typed configuration object, and corresponding `IOptions<T>` configuration
  - Enabled SSL support on PostgreSQL
  - Updated C# version to 8.0, and updated dependencies for RTM version of .NET Core 3.0

Also it seems you've commited credentials. Might wanna remedy that stat.